### PR TITLE
Inclusion of routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 group :development, :test do
   gem "neddinna", path: "../neddinna/"
 end
+gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,21 @@ PATH
 
 GEM
   specs:
+    coderay (1.1.0)
+    method_source (0.8.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.4)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   neddinna!
+  pry
 
 BUNDLED WITH
    1.10.6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < Neddinna::BaseController
+end

--- a/app/controllers/ned_controller.rb
+++ b/app/controllers/ned_controller.rb
@@ -1,0 +1,21 @@
+class NedController < ApplicationController
+  def index
+    "Index"
+  end
+
+  def new
+    "I am new"
+  end
+
+  def create
+    "Create"
+  end
+
+  def update
+    "Update"
+  end
+
+  def destroy
+    "Destroy"
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,11 @@
-require_relative "config/ned_application.rb"
+require "pry"
+require_relative "config/application.rb"
+require_relative "app/controllers/application_controller"
+require_relative "app/controllers/ned_controller"
+NedApplication = Application.new
+
+require_relative "config/routes.rb"
 Rack::Handler::WEBrick.run(
-  NedApplication.new,
+  NedApplication,
   Port: 4444
 )

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,0 +1,3 @@
+require "neddinna"
+class Application < Neddinna::Application
+end

--- a/config/ned_application.rb
+++ b/config/ned_application.rb
@@ -1,3 +1,0 @@
-require "neddinna"
-class NedApplication < Neddinna::Application
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,7 @@
+NedApplication.routes.draw do
+  get "/", to: "ned#index"
+  get "/ned/new", to: "ned#new"
+  post "/ned", to: "ned#create"
+  put "/ned", to: "ned#update"
+  delete "/ned", to: "ned#destroy"
+end


### PR DESCRIPTION
Why:
To allow for CRUD operations to be carried out on app.

This issue is fixed by:
Creating a route.rb file in config folder containing routes.
Creating an Application Controller that inherits from the framework BaseController.
Creating a NedController that inherits from Application Controller containing actions.

[Finishes #109951102]
